### PR TITLE
Added the options to output the RPM package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "electron-builder": "^3.24.0",
     "electron-prebuilt": "^1.0.1"
+    "electron-installer-redhat": "*"
 },
 "build": {
     "app-bundle-id": "com.listen1.listen1",
@@ -53,5 +54,6 @@
     "dist:win64": "build --platform win32 --arch x64",
     "dist:linux32": "build --platform linux --arch ia32",
     "dist:linux64": "build --platform linux --arch x64"
+    "dist:rpm64": "electron-packager . listen1 --platform linux --arch x64 --name='Listen 1' --version='1.0.1' --out dist/; electron-installer-redhat --src dist/listen1-linux-x64/ --dest dist/installers/ --arch x86_64"
   }
 }


### PR DESCRIPTION
run `npm run dist:rpm64` to generate RPM package for RedHat/Fedora.

This require the "rpmbuild" and "electron-installer-redhat" to be installed:

`sudo apt-get install rpm` on Ubuntu or `sudo dnf install rpm-build` on Fedora.

then `npm install --save-dev electron-installer-redhat`.

then you could run `npm run dist:rpm64` to get an RPM package.

