### PR TITLE
支持歌词翻译（仅支持网易云）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 dist
 package-lock.json
 yarn.lock
+.vscode

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "app/listen1_chrome_extension"]
 	path = app/listen1_chrome_extension
-	url = git@github.com:listen1/listen1_chrome_extension.git
+	url = git@github.com:reserveword/listen1_chrome_extension.git

--- a/app/floatingWindow.html
+++ b/app/floatingWindow.html
@@ -22,6 +22,9 @@
       user-select: none;
       transition: background ease-in-out 0.2s;
     }
+    div.contentTrans {
+      font-size: 20px;
+    }
     .title-bar {
       /*display: none;*/
       font-weight: bolder;

--- a/app/floatingWindow.html
+++ b/app/floatingWindow.html
@@ -9,7 +9,7 @@
       cursor: move;
       border-radius: 5px;
       background: rgba(36, 36, 36, 0.5);
-      height: 60px;
+      min-height: 60px;
       box-sizing: border-box;
       overflow: hidden;
       -webkit-app-region: drag;
@@ -17,13 +17,14 @@
       font-size: 24px;
       color: white;
       display: flex;
+      flex-direction: column;
       align-items: center;
       justify-content: center;
       user-select: none;
       transition: background ease-in-out 0.2s;
     }
-    div.contentTrans {
-      font-size: 20px;
+    span.contentTrans {
+      font-size: 18px;
     }
     .title-bar {
       /*display: none;*/
@@ -47,14 +48,21 @@
   </style>
 </head>
 <body>
-<div id="currentLyric" class="content">
-  Listen1
+<div id="currentLyricAll" class="content">
+  <span id="currentLyric" class="contentOriginal">Listen1</span>
+  <span id="currentLyricTrans" class="contentTrans"></span>
+</div>
+  
 </div>
 <script>
   const { ipcRenderer } = require('electron')
   currentLyric = document.getElementById('currentLyric')
   ipcRenderer.on('currentLyric', function (event, arg){
     currentLyric.innerHTML = arg;
+  });
+  currentLyricTrans = document.getElementById('currentLyricTrans')
+  ipcRenderer.on('currentLyricTrans', function (event, arg){
+    currentLyricTrans.innerHTML = arg;
   });
 </script>
 </body>

--- a/app/main.js
+++ b/app/main.js
@@ -269,7 +269,13 @@ function hack_referer_header(details) {
 
 ipcMain.on('currentLyric', (event, arg) => {
   if (floatingWindow && floatingWindow !== null) {
-    floatingWindow.webContents.send('currentLyric', arg);
+    if(typeof arg === 'string') {
+      floatingWindow.webContents.send('currentLyric', arg);
+      floatingWindow.webContents.send('currentLyricTrans', '');
+    } else {
+      floatingWindow.webContents.send('currentLyric', arg.lyric);
+      floatingWindow.webContents.send('currentLyricTrans', arg.tlyric);
+    }
   }
 })
 


### PR DESCRIPTION
[PR#360](https://github.com/listen1/listen1_chrome_extension/pull/360)
看了网易云的歌词api，返回值里有一个tlyric字段是翻译的歌词，
然后把tlyric一样解析一遍和原歌词一起排序，用translationFlag区分是原歌词还是翻译，
在传给浮窗的currentLyric事件中就用一个object作为容器，对浮窗显示部分也有一些微调，主要是为了换行显示和分别修改原歌词和翻译。
（P.S. 这个子模块我还不太会用，我pr给你的时候是不是应该把子模块切回你的repo？）