### PR TITLE
move jsmediatags to app/package.json

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -20,5 +20,8 @@
   "bugs": {
     "url": "https://github.com/listen1/listen1_desktop/issues"
   },
-  "homepage": "https://github.com/listen1/listen1_desktop#readme"
+  "homepage": "https://github.com/listen1/listen1_desktop#readme",
+  "dependencies": {
+    "jsmediatags": "^3.9.3"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -93,7 +93,6 @@
   "devDependencies": {
     "electron": "^11.2.0",
     "electron-builder": "^22.9.1",
-    "jsmediatags": "^3.9.3",
     "prettier": "^2.2.1"
   }
 }


### PR DESCRIPTION
The jsmediatags is not packed in electron-builder because it requires a [Two package.json Structure](https://www.electron.build/tutorials/two-package-structure) or asar disabled.
So sorry for that previous commit.  I guess I was self-defeating...