### PR TITLE
Simplify read audio tags

### DIFF
--- a/app/functions.js
+++ b/app/functions.js
@@ -1,22 +1,18 @@
 const mm = require("music-metadata");
 const path = require("path");
 module.exports = {
-  readAudioTags(filePath) {
-    return new Promise((resolve, reject) => {
-      let tag = {};
-      tag.tags = {
+  async readAudioTags(filePath) {
+    const tag = {
+      tags: {
         title: path.basename(filePath, path.extname(filePath)),
         artist: "",
         album: "",
-      };
-      mm.parseFile(filePath)
-        .then((metaData) => {
-          tag.tags = metaData.common;
-          resolve(tag);
-        })
-        .catch(() => {
-          resolve(tag);
-        });
-    });
-  },
+      }
+    };
+    try {
+      tag.tags = (await mm.parseFile(filePath)).common;
+    } catch(err) {
+    }
+    return tag;
+  }
 };


### PR DESCRIPTION
Note that the `.catch` is very tricky, it will also catch errors occurred in `resolve(tag)`.
```js
mm.parseFile(filePath)
  .then((metaData) => {
    tag.tags = metaData.common;
    resolve(tag); // does catch errors in resolve
  })
  .catch(() => {
    resolve(tag); 
  });
```

Using `.then`, use this instead:
```js
mm.parseFile(filePath)
  .then((metaData) => {
    tag.tags = metaData.common;
    resolve(tag); // does NOT catch errors in resolve
  }, () => {
    resolve(tag); // 
  });
```

But I could not resist to simplify further, used `async` and `await` instead.