### PR TITLE
submodule: use http url instead of ssh

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "app/listen1_chrome_extension"]
 	path = app/listen1_chrome_extension
-	url = git@github.com:listen1/listen1_chrome_extension.git
+	url = https://github.com/listen1/listen1_chrome_extension.git

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -12,18 +12,18 @@
         "chardet": "^1.3.0",
         "electron-store": "^8.0.0",
         "electron-updater": "^4.3.10",
-        "music-metadata": "^7.11.0"
+        "music-metadata": "^7.11.4"
       }
     },
     "node_modules/@tokenizer/token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "node_modules/@types/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-4g1jrL98mdOIwSOUh6LTlB0Cs9I0dQPwINUhBg7C6pN4HLr8GS8xsksJxilW6S6dQHVi2K/o+lQuQcg7LroCnw=="
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now=="
     },
     "node_modules/ajv": {
       "version": "8.6.2",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/ajv-formats": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
-      "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "dependencies": {
         "ajv": "^8.0.0"
       },
@@ -70,9 +70,9 @@
       }
     },
     "node_modules/builder-util-runtime": {
-      "version": "8.7.8",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.8.tgz",
-      "integrity": "sha512-j7V45HIXX5dzminZLVKlmgmqaXpt44CcpFVEjlkO6zPM3IQFjeb+jvOKcqygg5MK3Q1Q5l4Jj9m9xZp0Rc4TiQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.8.1.tgz",
+      "integrity": "sha512-xHxAzdsJmMV8m/N+INzYUKfyJASeKyKHnA1uGkY8Y8JKLI/c4BG+If+L0If2YETv96CiRASkvd02tIt2pvrchQ==",
       "dependencies": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
@@ -87,9 +87,9 @@
       "integrity": "sha512-cyTQGGptIjIT+CMGT5J/0l9c6Fb+565GCFjjeUTKxUO7w3oR+FcNCMEKTn5xtVKaLFmladN7QF68IiQsv5Fbdw=="
     },
     "node_modules/conf": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-10.0.1.tgz",
-      "integrity": "sha512-QClEoNcruwBL84QgMEPHibL3ERxWIrRKhbjJKG1VsFBadm5QpS0jsu4QjY/maxUvhyAKXeyrs+ws+lC6PajnEg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.0.2.tgz",
+      "integrity": "sha512-iyy4ArqyQ/yrzNASNBN+jaylu53JRuq0ztvL6KAWYHj4iN56BVuhy2SrzEEHBodNbacZr2Pd/4nWhoAwc66T1g==",
       "dependencies": {
         "ajv": "^8.1.0",
         "ajv-formats": "^2.0.2",
@@ -174,12 +174,12 @@
       }
     },
     "node_modules/electron-updater": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.4.1.tgz",
-      "integrity": "sha512-Lymn9Y80LduugHiV9NRHq0ao4jXNh7RO02ZOK92rv7dH/+3xwBVZFWMmAYFGLvjTcepPGiw9q5vdAH3sumrJGw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.5.1.tgz",
+      "integrity": "sha512-cdUqwprM4dRgifT5jzPTtEs8bZ6WyrVw15uS0eenTQnsIUbjviOeJhAQtZ+bKXP5bEG6SvR6wAkmDokRlVcctw==",
       "dependencies": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "8.7.8",
+        "builder-util-runtime": "8.8.1",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -202,63 +202,19 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "node_modules/file-type": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.2.tgz",
-      "integrity": "sha512-lnHRZj2USLF3v4C5ZY7/vQQeoTVA1YV9TtD6UUCr9z5Cd0uyutqxPBJxkXzM6lufPNuSfefq/yFmnSPz0C3wNw==",
+      "version": "16.5.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
+      "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
       "dependencies": {
         "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "6.1.3",
-        "token-types": "^3.0.0"
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       },
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sindresorhus/file-type?sponsor=1"
-      }
-    },
-    "node_modules/file-type/node_modules/peek-readable": {
-      "version": "3.1.4",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.4.tgz",
-      "integrity": "sha512-DX7ec7frSMtCWw+zMd27f66hcxIz/w9LQTY2RflB4WNHCVPAye1pJiP2t3gvaaOhu7IOhtPbHw8MemMj+F5lrg==",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/file-type/node_modules/strtok3": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.1.3.tgz",
-      "integrity": "sha512-ssWSKFOeUTurMSucgyUf+a6Z9mVTYrsYiyEK5RLnh8BM6sFrKSljVlnjZXIDxMguYfdQI+mUPFHo88FYTxq1XA==",
-      "dependencies": {
-        "@tokenizer/token": "^0.1.1",
-        "peek-readable": "^3.1.4"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
-      }
-    },
-    "node_modules/file-type/node_modules/token-types": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-3.1.0.tgz",
-      "integrity": "sha512-WhoeIW7UTn7NC7L0t/4x3vU/YYSS1oeUxYgiGXQLd82Kaf1qtlxOex3ETY0+o2QuRgAdyursMlUhQBKDCfMUkQ==",
-      "dependencies": {
-        "@tokenizer/token": "^0.1.1",
-        "ieee754": "^1.2.1"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/find-up": {
@@ -286,9 +242,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -414,16 +370,16 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "node_modules/music-metadata": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.11.0.tgz",
-      "integrity": "sha512-mDS6tZt0csbKCpWJcUlyjv5OIYUHnDDLm7phwRmVT/2jSPxHjvwZwUOx2/dD+uH5n2XGTB0iAqWNtmZJO4L3Hw==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.11.4.tgz",
+      "integrity": "sha512-pEaS/vRo0zCAWJ0y5zZ5ruM8CvPPJ/VXbevRMUVkZkWN8rZAQun04xx09/3/PV0qS3nlrzPUDCRK6jDrbGVtUg==",
       "dependencies": {
         "content-type": "^1.0.4",
         "debug": "^4.3.2",
-        "file-type": "16.5.2",
+        "file-type": "16.5.3",
         "media-typer": "^1.1.0",
-        "strtok3": "^6.2.2",
-        "token-types": "^4.1.0"
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       },
       "engines": {
         "node": ">=10"
@@ -497,9 +453,9 @@
       }
     },
     "node_modules/peek-readable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.0.0.tgz",
-      "integrity": "sha512-kLbU4cz6h86poGVBKgAVMpFmD47nX04fPPQNKnv9fuj+IJZYkEBjsYAVu5nDbZWx0ZsWwWlMzeG90zQa5KLBaA==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.0.1.tgz",
+      "integrity": "sha512-7qmhptnR0WMSpxT5rMHG9bW/mYSR1uqaPFj2MHvT+y/aOUu6msJijpKt5SkTDKySwg65OWG2JwTMBlgcbwMHrQ==",
       "engines": {
         "node": ">=8"
       },
@@ -610,11 +566,12 @@
       }
     },
     "node_modules/strtok3": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.2.2.tgz",
-      "integrity": "sha512-iUzLl3UhF2RfqQah80JngnfltQFLEidGyTX8+hHFMQFjzUj3UpIpOx824FtFmRI9bwyywReENpdHGDkFJwJlGQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.2.4.tgz",
+      "integrity": "sha512-GO8IcFF9GmFDvqduIspUBwCzCbqzegyVKIsSymcMgiZKeCfrN9SowtUoi8+b59WZMAjIzVZic/Ft97+pynR3Iw==",
       "dependencies": {
-        "peek-readable": "^4.0.0"
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.0.1"
       },
       "engines": {
         "node": ">=10"
@@ -625,10 +582,11 @@
       }
     },
     "node_modules/token-types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.0.tgz",
-      "integrity": "sha512-2JV21LhBx3WsTveWcXp20SDo0/fQ2TK2RFcFBIRDvkOIy6+E79n+rqMuvolqyuWPgYazCrHXWpE0OxRj43nb9Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
+      "integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
       "dependencies": {
+        "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       },
       "engines": {
@@ -640,9 +598,9 @@
       }
     },
     "node_modules/type-fest": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.2.tgz",
-      "integrity": "sha512-pfkPYCcuV0TJoo/jlsUeWNV8rk7uMU6ocnYNvca1Vu+pyKi8Rl8Zo2scPt9O72gCsXIm+dMxOOWuA3VFDSdzWA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
       "engines": {
         "node": ">=10"
       },
@@ -679,14 +637,14 @@
   },
   "dependencies": {
     "@tokenizer/token": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.1.1.tgz",
-      "integrity": "sha512-XO6INPbZCxdprl+9qa/AAbFFOMzzwqYxpjPgLICrMD6C2FCw6qfJOPcBk6JqqPLSaZ/Qx87qn4rpPmPMwaAK6w=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="
     },
     "@types/semver": {
-      "version": "7.3.7",
-      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.7.tgz",
-      "integrity": "sha512-4g1jrL98mdOIwSOUh6LTlB0Cs9I0dQPwINUhBg7C6pN4HLr8GS8xsksJxilW6S6dQHVi2K/o+lQuQcg7LroCnw=="
+      "version": "7.3.8",
+      "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.3.8.tgz",
+      "integrity": "sha512-D/2EJvAlCEtYFEYmmlGwbGXuK886HzyCc3nZX/tkFTQdEU8jZDAgiv08P162yB17y4ZXZoq7yFAnW4GDBb9Now=="
     },
     "ajv": {
       "version": "8.6.2",
@@ -700,9 +658,9 @@
       }
     },
     "ajv-formats": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.0.tgz",
-      "integrity": "sha512-USH2jBb+C/hIpwD2iRjp0pe0k+MvzG0mlSn/FIdCgQhUb9ALPRjt2KIQdfZDS9r0ZIeUAg7gOu9KL0PFqGqr5Q==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-2.1.1.tgz",
+      "integrity": "sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==",
       "requires": {
         "ajv": "^8.0.0"
       }
@@ -718,9 +676,9 @@
       "integrity": "sha512-Xcz9l0z7y9yQ9rdDaxlmaI4uJHf/T8g9hOEzJcsEqX2SjCj4J20uK7+ldkDHMbpJDK76wF7xEIgxc/vSlsfw5w=="
     },
     "builder-util-runtime": {
-      "version": "8.7.8",
-      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.7.8.tgz",
-      "integrity": "sha512-j7V45HIXX5dzminZLVKlmgmqaXpt44CcpFVEjlkO6zPM3IQFjeb+jvOKcqygg5MK3Q1Q5l4Jj9m9xZp0Rc4TiQ==",
+      "version": "8.8.1",
+      "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-8.8.1.tgz",
+      "integrity": "sha512-xHxAzdsJmMV8m/N+INzYUKfyJASeKyKHnA1uGkY8Y8JKLI/c4BG+If+L0If2YETv96CiRASkvd02tIt2pvrchQ==",
       "requires": {
         "debug": "^4.3.2",
         "sax": "^1.2.4"
@@ -732,9 +690,9 @@
       "integrity": "sha512-cyTQGGptIjIT+CMGT5J/0l9c6Fb+565GCFjjeUTKxUO7w3oR+FcNCMEKTn5xtVKaLFmladN7QF68IiQsv5Fbdw=="
     },
     "conf": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/conf/-/conf-10.0.1.tgz",
-      "integrity": "sha512-QClEoNcruwBL84QgMEPHibL3ERxWIrRKhbjJKG1VsFBadm5QpS0jsu4QjY/maxUvhyAKXeyrs+ws+lC6PajnEg==",
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/conf/-/conf-10.0.2.tgz",
+      "integrity": "sha512-iyy4ArqyQ/yrzNASNBN+jaylu53JRuq0ztvL6KAWYHj4iN56BVuhy2SrzEEHBodNbacZr2Pd/4nWhoAwc66T1g==",
       "requires": {
         "ajv": "^8.1.0",
         "ajv-formats": "^2.0.2",
@@ -787,12 +745,12 @@
       }
     },
     "electron-updater": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.4.1.tgz",
-      "integrity": "sha512-Lymn9Y80LduugHiV9NRHq0ao4jXNh7RO02ZOK92rv7dH/+3xwBVZFWMmAYFGLvjTcepPGiw9q5vdAH3sumrJGw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-4.5.1.tgz",
+      "integrity": "sha512-cdUqwprM4dRgifT5jzPTtEs8bZ6WyrVw15uS0eenTQnsIUbjviOeJhAQtZ+bKXP5bEG6SvR6wAkmDokRlVcctw==",
       "requires": {
         "@types/semver": "^7.3.6",
-        "builder-util-runtime": "8.7.8",
+        "builder-util-runtime": "8.8.1",
         "fs-extra": "^10.0.0",
         "js-yaml": "^4.1.0",
         "lazy-val": "^1.0.5",
@@ -812,38 +770,13 @@
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
     "file-type": {
-      "version": "16.5.2",
-      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.2.tgz",
-      "integrity": "sha512-lnHRZj2USLF3v4C5ZY7/vQQeoTVA1YV9TtD6UUCr9z5Cd0uyutqxPBJxkXzM6lufPNuSfefq/yFmnSPz0C3wNw==",
+      "version": "16.5.3",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-16.5.3.tgz",
+      "integrity": "sha512-uVsl7iFhHSOY4bEONLlTK47iAHtNsFHWP5YE4xJfZ4rnX7S1Q3wce09XgqSC7E/xh8Ncv/be1lNoyprlUH/x6A==",
       "requires": {
         "readable-web-to-node-stream": "^3.0.0",
-        "strtok3": "6.1.3",
-        "token-types": "^3.0.0"
-      },
-      "dependencies": {
-        "peek-readable": {
-          "version": "3.1.4",
-          "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-3.1.4.tgz",
-          "integrity": "sha512-DX7ec7frSMtCWw+zMd27f66hcxIz/w9LQTY2RflB4WNHCVPAye1pJiP2t3gvaaOhu7IOhtPbHw8MemMj+F5lrg=="
-        },
-        "strtok3": {
-          "version": "6.1.3",
-          "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.1.3.tgz",
-          "integrity": "sha512-ssWSKFOeUTurMSucgyUf+a6Z9mVTYrsYiyEK5RLnh8BM6sFrKSljVlnjZXIDxMguYfdQI+mUPFHo88FYTxq1XA==",
-          "requires": {
-            "@tokenizer/token": "^0.1.1",
-            "peek-readable": "^3.1.4"
-          }
-        },
-        "token-types": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/token-types/-/token-types-3.1.0.tgz",
-          "integrity": "sha512-WhoeIW7UTn7NC7L0t/4x3vU/YYSS1oeUxYgiGXQLd82Kaf1qtlxOex3ETY0+o2QuRgAdyursMlUhQBKDCfMUkQ==",
-          "requires": {
-            "@tokenizer/token": "^0.1.1",
-            "ieee754": "^1.2.1"
-          }
-        }
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       }
     },
     "find-up": {
@@ -865,9 +798,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg=="
     },
     "ieee754": {
       "version": "1.2.1",
@@ -959,16 +892,16 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
     },
     "music-metadata": {
-      "version": "7.11.0",
-      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.11.0.tgz",
-      "integrity": "sha512-mDS6tZt0csbKCpWJcUlyjv5OIYUHnDDLm7phwRmVT/2jSPxHjvwZwUOx2/dD+uH5n2XGTB0iAqWNtmZJO4L3Hw==",
+      "version": "7.11.4",
+      "resolved": "https://registry.npmjs.org/music-metadata/-/music-metadata-7.11.4.tgz",
+      "integrity": "sha512-pEaS/vRo0zCAWJ0y5zZ5ruM8CvPPJ/VXbevRMUVkZkWN8rZAQun04xx09/3/PV0qS3nlrzPUDCRK6jDrbGVtUg==",
       "requires": {
         "content-type": "^1.0.4",
         "debug": "^4.3.2",
-        "file-type": "16.5.2",
+        "file-type": "16.5.3",
         "media-typer": "^1.1.0",
-        "strtok3": "^6.2.2",
-        "token-types": "^4.1.0"
+        "strtok3": "^6.2.4",
+        "token-types": "^4.1.1"
       }
     },
     "onetime": {
@@ -1013,9 +946,9 @@
       "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
     },
     "peek-readable": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.0.0.tgz",
-      "integrity": "sha512-kLbU4cz6h86poGVBKgAVMpFmD47nX04fPPQNKnv9fuj+IJZYkEBjsYAVu5nDbZWx0ZsWwWlMzeG90zQa5KLBaA=="
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/peek-readable/-/peek-readable-4.0.1.tgz",
+      "integrity": "sha512-7qmhptnR0WMSpxT5rMHG9bW/mYSR1uqaPFj2MHvT+y/aOUu6msJijpKt5SkTDKySwg65OWG2JwTMBlgcbwMHrQ=="
     },
     "pkg-up": {
       "version": "3.1.0",
@@ -1080,25 +1013,27 @@
       }
     },
     "strtok3": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.2.2.tgz",
-      "integrity": "sha512-iUzLl3UhF2RfqQah80JngnfltQFLEidGyTX8+hHFMQFjzUj3UpIpOx824FtFmRI9bwyywReENpdHGDkFJwJlGQ==",
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-6.2.4.tgz",
+      "integrity": "sha512-GO8IcFF9GmFDvqduIspUBwCzCbqzegyVKIsSymcMgiZKeCfrN9SowtUoi8+b59WZMAjIzVZic/Ft97+pynR3Iw==",
       "requires": {
-        "peek-readable": "^4.0.0"
+        "@tokenizer/token": "^0.3.0",
+        "peek-readable": "^4.0.1"
       }
     },
     "token-types": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.0.tgz",
-      "integrity": "sha512-2JV21LhBx3WsTveWcXp20SDo0/fQ2TK2RFcFBIRDvkOIy6+E79n+rqMuvolqyuWPgYazCrHXWpE0OxRj43nb9Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-4.1.1.tgz",
+      "integrity": "sha512-hD+QyuUAyI2spzsI0B7gf/jJ2ggR4RjkAo37j3StuePhApJUwcWDjnHDOFdIWYSwNR28H14hpwm4EI+V1Ted1w==",
       "requires": {
+        "@tokenizer/token": "^0.3.0",
         "ieee754": "^1.2.1"
       }
     },
     "type-fest": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.2.2.tgz",
-      "integrity": "sha512-pfkPYCcuV0TJoo/jlsUeWNV8rk7uMU6ocnYNvca1Vu+pyKi8Rl8Zo2scPt9O72gCsXIm+dMxOOWuA3VFDSdzWA=="
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
+      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
     },
     "universalify": {
       "version": "2.0.0",

--- a/app/package.json
+++ b/app/package.json
@@ -25,6 +25,6 @@
     "chardet": "^1.3.0",
     "electron-store": "^8.0.0",
     "electron-updater": "^4.3.10",
-    "music-metadata": "^7.11.0"
+    "music-metadata": "^7.11.4"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "devDependencies": {
-        "electron": "^13.1.7",
+        "electron": "^13.3.0",
         "electron-builder": "^22.11.7",
         "prettier": "^2.3.2"
       }
@@ -33,9 +33,9 @@
       }
     },
     "node_modules/@electron/get": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.4.tgz",
-      "integrity": "sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.13.0.tgz",
+      "integrity": "sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==",
       "dev": true,
       "dependencies": {
         "debug": "^4.1.1",
@@ -201,10 +201,13 @@
       }
     },
     "node_modules/@types/debug": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.6.tgz",
-      "integrity": "sha512-7fDOJFA/x8B+sO1901BmHlf5dE1cxBU8mRXj8QOEDnn16hhGJv/IHxJtZhvsabZsIMn0eLIyeOKAeqSNJJYTpA==",
-      "dev": true
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "dependencies": {
+        "@types/ms": "*"
+      }
     },
     "node_modules/@types/fs-extra": {
       "version": "9.0.12",
@@ -233,10 +236,16 @@
       "dev": true,
       "optional": true
     },
+    "node_modules/@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "node_modules/@types/node": {
-      "version": "14.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
-      "integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
+      "version": "14.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.12.tgz",
+      "integrity": "sha512-vhUqgjJR1qxwTWV5Ps5txuy2XMdf7Fw+OrdChRboy8BmWUPkckOhphaohzFG6b8DW7CrxaBMdrdJ47SYFq1okw==",
       "dev": true
     },
     "node_modules/@types/plist": {
@@ -566,9 +575,9 @@
       }
     },
     "node_modules/boolean": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.2.tgz",
-      "integrity": "sha512-YN6UmV0FfLlBVvRvNPx3pz5W/mUoYB24J4WSXOKP/OOJpi+Oq6WYqPaNTHzjI0QzwWtnvEd5CGYyQPgp1jFxnw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
+      "integrity": "sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==",
       "dev": true,
       "optional": true
     },
@@ -710,9 +719,9 @@
       }
     },
     "node_modules/buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "node_modules/builder-util": {
@@ -840,9 +849,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -1049,9 +1058,9 @@
       }
     },
     "node_modules/core-js": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
-      "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
+      "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
       "dev": true,
       "hasInstallScript": true,
       "optional": true,
@@ -1331,9 +1340,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "13.1.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.1.7.tgz",
-      "integrity": "sha512-sVfpP/0s6a82FK32LMuEe9L+aWZw15u3uYn9xUJArPjy4OZHteE6yM5871YCNXNiDnoCLQ5eqQWipiVgHsf8nQ==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
+      "integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -1777,9 +1786,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
     "node_modules/graceful-readlink": {
@@ -2408,15 +2417,14 @@
       }
     },
     "node_modules/plist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
-      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.4.tgz",
+      "integrity": "sha512-ksrr8y9+nXOxQB2osVNqrgvX/XQPOXaU4BQMKjYq8PvaY1U18mo+fKgBSwzK+luSyinOuPae956lSVcBwxlAMg==",
       "dev": true,
       "optional": true,
       "dependencies": {
         "base64-js": "^1.5.1",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "^0.5.0"
+        "xmlbuilder": "^9.0.7"
       },
       "engines": {
         "node": ">=6"
@@ -2739,9 +2747,9 @@
       }
     },
     "node_modules/smart-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "optional": true,
       "engines": {
@@ -3286,16 +3294,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "dev": true,
-      "optional": true,
-      "engines": {
-        "node": ">=10.0.0"
-      }
-    },
     "node_modules/y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -3312,9 +3310,9 @@
       "dev": true
     },
     "node_modules/yargs": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
-      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
       "dev": true,
       "dependencies": {
         "cliui": "^7.0.2",
@@ -3411,9 +3409,9 @@
       }
     },
     "@electron/get": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.12.4.tgz",
-      "integrity": "sha512-6nr9DbJPUR9Xujw6zD3y+rS95TyItEVM0NVjt1EehY2vUWfIgPiIPVHxCvaTS0xr2B+DRxovYVKbuOWqC35kjg==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@electron/get/-/get-1.13.0.tgz",
+      "integrity": "sha512-+SjZhRuRo+STTO1Fdhzqnv9D2ZhjxXP6egsJ9kiO8dtP68cDx7dFCwWi64dlMQV7sWcfW1OYCW4wviEBzmRsfQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -3537,10 +3535,13 @@
       }
     },
     "@types/debug": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.6.tgz",
-      "integrity": "sha512-7fDOJFA/x8B+sO1901BmHlf5dE1cxBU8mRXj8QOEDnn16hhGJv/IHxJtZhvsabZsIMn0eLIyeOKAeqSNJJYTpA==",
-      "dev": true
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz",
+      "integrity": "sha512-9AonUzyTjXXhEOa0DnqpzZi6VHlqKMswga9EXjpXnnqxwLtdvPPtlO8evrI5D9S6asFRCQ6v+wpiUKbw+vKqyg==",
+      "dev": true,
+      "requires": {
+        "@types/ms": "*"
+      }
     },
     "@types/fs-extra": {
       "version": "9.0.12",
@@ -3569,10 +3570,16 @@
       "dev": true,
       "optional": true
     },
+    "@types/ms": {
+      "version": "0.7.31",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-0.7.31.tgz",
+      "integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA==",
+      "dev": true
+    },
     "@types/node": {
-      "version": "14.17.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
-      "integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
+      "version": "14.17.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.12.tgz",
+      "integrity": "sha512-vhUqgjJR1qxwTWV5Ps5txuy2XMdf7Fw+OrdChRboy8BmWUPkckOhphaohzFG6b8DW7CrxaBMdrdJ47SYFq1okw==",
       "dev": true
     },
     "@types/plist": {
@@ -3834,9 +3841,9 @@
       }
     },
     "boolean": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.2.tgz",
-      "integrity": "sha512-YN6UmV0FfLlBVvRvNPx3pz5W/mUoYB24J4WSXOKP/OOJpi+Oq6WYqPaNTHzjI0QzwWtnvEd5CGYyQPgp1jFxnw==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.1.4.tgz",
+      "integrity": "sha512-3hx0kwU3uzG6ReQ3pnaFQPSktpBw6RHN3/ivDKEuU8g1XSfafowyvDnadjv1xp8IZqhtSukxlwv9bF6FhX8m0w==",
       "dev": true,
       "optional": true
     },
@@ -3936,9 +3943,9 @@
       "dev": true
     },
     "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "dev": true
     },
     "builder-util": {
@@ -4041,9 +4048,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.1.tgz",
-      "integrity": "sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -4210,9 +4217,9 @@
       }
     },
     "core-js": {
-      "version": "3.15.2",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.15.2.tgz",
-      "integrity": "sha512-tKs41J7NJVuaya8DxIOCnl8QuPHx5/ZVbFo1oKgVl1qHFBBrDctzQGtuLjPpRdNTWmKPH6oEvgN/MUID+l485Q==",
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.16.3.tgz",
+      "integrity": "sha512-lM3GftxzHNtPNUJg0v4pC2RC6puwMd6VZA7vXUczi+SKmCWSf4JwO89VJGMqbzmB7jlK7B5hr3S64PqwFL49cA==",
       "dev": true,
       "optional": true
     },
@@ -4428,9 +4435,9 @@
       }
     },
     "electron": {
-      "version": "13.1.7",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-13.1.7.tgz",
-      "integrity": "sha512-sVfpP/0s6a82FK32LMuEe9L+aWZw15u3uYn9xUJArPjy4OZHteE6yM5871YCNXNiDnoCLQ5eqQWipiVgHsf8nQ==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-13.3.0.tgz",
+      "integrity": "sha512-d/BvOLDjI4i7yf9tqCuLL2fFGA2TrM/D9PyRpua+rJolG0qrwp/FohP02L0m+44kmPpofIo4l3NPwLmzyKKimA==",
       "dev": true,
       "requires": {
         "@electron/get": "^1.0.1",
@@ -4785,9 +4792,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
-      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.8.tgz",
+      "integrity": "sha512-qkIilPUYcNhJpd33n0GBXTB1MMPp14TxEsEs0pTrsSVucApsYzW5V+Q8Qxhik6KU3evy+qkAAowTByymK0avdg==",
       "dev": true
     },
     "graceful-readlink": {
@@ -5263,15 +5270,14 @@
       "optional": true
     },
     "plist": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.2.tgz",
-      "integrity": "sha512-MSrkwZBdQ6YapHy87/8hDU8MnIcyxBKjeF+McXnr5A9MtffPewTs7G3hlpodT5TacyfIyFTaJEhh3GGcmasTgQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.4.tgz",
+      "integrity": "sha512-ksrr8y9+nXOxQB2osVNqrgvX/XQPOXaU4BQMKjYq8PvaY1U18mo+fKgBSwzK+luSyinOuPae956lSVcBwxlAMg==",
       "dev": true,
       "optional": true,
       "requires": {
         "base64-js": "^1.5.1",
-        "xmlbuilder": "^9.0.7",
-        "xmldom": "^0.5.0"
+        "xmlbuilder": "^9.0.7"
       },
       "dependencies": {
         "xmlbuilder": {
@@ -5527,9 +5533,9 @@
       }
     },
     "smart-buffer": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.1.0.tgz",
-      "integrity": "sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==",
       "dev": true,
       "optional": true
     },
@@ -5962,13 +5968,6 @@
       "dev": true,
       "optional": true
     },
-    "xmldom": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.5.0.tgz",
-      "integrity": "sha512-Foaj5FXVzgn7xFzsKeNIde9g6aFBxTPi37iwsno8QvApmtg7KYrr+OPyRHcJF7dud2a5nGRBXK3n0dL62Gf7PA==",
-      "dev": true,
-      "optional": true
-    },
     "y18n": {
       "version": "5.0.8",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
@@ -5982,9 +5981,9 @@
       "dev": true
     },
     "yargs": {
-      "version": "17.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.0.1.tgz",
-      "integrity": "sha512-xBBulfCc8Y6gLFcrPvtqKz9hz8SO0l1Ni8GgDekvBX2ro0HRQImDGnikfc33cgzcYUSncapnNcZDjVFIH3f6KQ==",
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.1.1.tgz",
+      "integrity": "sha512-c2k48R0PwKIqKhPMWjeiF6y2xY/gPMUlro0sgxqXpbOIohWiLNXWslsootttv7E1e73QPAMQSg5FeySbVcpsPQ==",
       "dev": true,
       "requires": {
         "cliui": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     }
   },
   "devDependencies": {
-    "electron": "^13.1.7",
+    "electron": "^13.3.0",
     "electron-builder": "^22.11.7",
     "prettier": "^2.3.2"
   }


### PR DESCRIPTION
chore: bump deps
Also, electron 14 is released with the removal of `remote` and the support of windows control overlay. I'm planning to migrate to that in the next pr. 
Also, I think that we should also create a `next` branch or make the `chrome_extension` repo a monorepo so that we can test the v3 on desktop builds.