### PR TITLE
Update main.js

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -575,6 +575,14 @@ ipcMain.on("currentLyric", (event, arg) => {
       floatingWindow.webContents.send("currentLyricTrans", arg.tlyric);
     }
   }
+  // 增加macOS 状态栏歌词展示
+  if (process.platform === "darwin") {
+    if (typeof arg === "string") {
+      appTray.setTitle(arg)
+    } else {
+      appTray.setTitle(arg.lyric)
+    }
+  }
 });
 
 ipcMain.on("trackPlayingNow", (event, track) => {


### PR DESCRIPTION
1、 增加macOS 状态栏歌词展示

没有增加新的设置开关只是添加了一个平台的判断，另外查看了electron 的文档也没有发现Tray能调整 image 和 title的位置的api，原生平台可以直接设置image position 就可以做到类似QQ音乐的效果， 当前效果如下
![image](https://user-images.githubusercontent.com/12983090/152493634-5820df77-e30c-45a6-8295-9e4a52017472.png)
