### PR TITLE
Fix to use hardware acceleration on linux

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -38,8 +38,6 @@ switch (process.platform) {
     break;
   case "linux":
     trayIconPath = join(__dirname, "/resources/logo_32.png");
-    // fix transparent window not working in linux bug
-    app.disableHardwareAcceleration();
     break;
   case "win32":
     trayIconPath = join(__dirname, "/resources/logo_32.png");


### PR DESCRIPTION
在现代主题下 禁用硬件加速的性能是不可接受的